### PR TITLE
Update MSS_Thirst_WaterQuest.xml

### DIFF
--- a/Compatibility/sarg.alphapropsparks/Patches/MSS_Thirst_WaterQuest.xml
+++ b/Compatibility/sarg.alphapropsparks/Patches/MSS_Thirst_WaterQuest.xml
@@ -1,57 +1,86 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Patch>
-    <Operation Class="PatchOperationAdd">
-        <xpath>Defs/ThingDef[defName="ArchonexusCore"]/comps</xpath>
-        <value>
-            <li Class="CompProperties_FleckEmitter">
-                <fleck>AP_WaterSproutLateral_Fleck</fleck>
-                <emissionInterval>60</emissionInterval>
-                <offset>(2,0,1.5)</offset>
-            </li>
-        </value>
-    </Operation>
 
-    <Operation Class="PatchOperationAdd">
-        <xpath>Defs/ThingDef[defName="ArchonexusCore"]/comps</xpath>
-        <value>
-            <li Class="CompProperties_FleckEmitter">
-                <fleck>AP_WaterSproutLateralInverted_Fleck</fleck>
-                <emissionInterval>60</emissionInterval>
-                <offset>(-2,0,1.5)</offset>
-            </li>
-        </value>
-    </Operation>
+  <!-- 
+    Adds multiple fleck emitter comps to the 'ArchonexusCore'.
+    Each <Operation> appends one new fleck emitter with its unique offset 
+    and emission parameters.
+  -->
 
-    <Operation Class="PatchOperationAdd">
-        <xpath>Defs/ThingDef[defName="ArchonexusCore"]/comps</xpath>
-        <value>
-            <li Class="CompProperties_FleckEmitter">
-                <fleck>AP_SmallWaterSproutAnimated_Fleck</fleck>
-                <emissionInterval>60</emissionInterval>
-                <offset>(2,0,0)</offset>
-            </li>
-        </value>
-    </Operation>
+  <!-- =========================================================
+       Fleck Emitter: WaterSprout Lateral
+       Sprays sideways water effect at position (2,0,1.5)
+      ========================================================= -->
+  <Operation Class="PatchOperationAdd">
+    <xpath>Defs/ThingDef[defName="ArchonexusCore"]/comps</xpath>
+    <value>
+      <li Class="CompProperties_FleckEmitter">
+        <fleck>AP_WaterSproutLateral_Fleck</fleck>
+        <emissionInterval>60</emissionInterval>
+        <offset>(2,0,1.5)</offset>
+        <!-- Optional: <fleckScale>1.0</fleckScale> or <randomRotation>true</randomRotation> -->
+      </li>
+    </value>
+  </Operation>
 
-    <Operation Class="PatchOperationAdd">
-        <xpath>Defs/ThingDef[defName="ArchonexusCore"]/comps</xpath>
-        <value>
-            <li Class="CompProperties_FleckEmitter">
-                <fleck>AP_SmallWaterSproutAnimatedInverted_Fleck</fleck>
-                <emissionInterval>60</emissionInterval>
-                <offset>(-2,0,0)</offset>
-            </li>
-        </value>
-    </Operation>
+  <!-- =========================================================
+       Fleck Emitter: WaterSprout Lateral Inverted
+       Sprays sideways water effect mirrored at position (-2,0,1.5)
+      ========================================================= -->
+  <Operation Class="PatchOperationAdd">
+    <xpath>Defs/ThingDef[defName="ArchonexusCore"]/comps</xpath>
+    <value>
+      <li Class="CompProperties_FleckEmitter">
+        <fleck>AP_WaterSproutLateralInverted_Fleck</fleck>
+        <emissionInterval>60</emissionInterval>
+        <offset>(-2,0,1.5)</offset>
+      </li>
+    </value>
+  </Operation>
 
-    <Operation Class="PatchOperationAdd">
-        <xpath>Defs/ThingDef[defName="ArchonexusCore"]/comps</xpath>
-        <value>
-            <li Class="CompProperties_FleckEmitter">
-                <fleck>AP_WaterSprout_FleckLarge</fleck>
-                <emissionInterval>60</emissionInterval>
-                <offset>(0,0,-2)</offset>
-            </li>
-        </value>
-    </Operation>
+  <!-- =========================================================
+       Fleck Emitter: Small Water Sprout Animated
+       Sprays a smaller animated effect at position (2,0,0)
+      ========================================================= -->
+  <Operation Class="PatchOperationAdd">
+    <xpath>Defs/ThingDef[defName="ArchonexusCore"]/comps</xpath>
+    <value>
+      <li Class="CompProperties_FleckEmitter">
+        <fleck>AP_SmallWaterSproutAnimated_Fleck</fleck>
+        <emissionInterval>60</emissionInterval>
+        <offset>(2,0,0)</offset>
+      </li>
+    </value>
+  </Operation>
+
+  <!-- =========================================================
+       Fleck Emitter: Small Water Sprout Animated Inverted
+       Same effect mirrored at position (-2,0,0)
+      ========================================================= -->
+  <Operation Class="PatchOperationAdd">
+    <xpath>Defs/ThingDef[defName="ArchonexusCore"]/comps</xpath>
+    <value>
+      <li Class="CompProperties_FleckEmitter">
+        <fleck>AP_SmallWaterSproutAnimatedInverted_Fleck</fleck>
+        <emissionInterval>60</emissionInterval>
+        <offset>(-2,0,0)</offset>
+      </li>
+    </value>
+  </Operation>
+
+  <!-- =========================================================
+       Fleck Emitter: Large Water Sprout
+       A single large vertical water effect at position (0,0,-2)
+      ========================================================= -->
+  <Operation Class="PatchOperationAdd">
+    <xpath>Defs/ThingDef[defName="ArchonexusCore"]/comps</xpath>
+    <value>
+      <li Class="CompProperties_FleckEmitter">
+        <fleck>AP_WaterSprout_FleckLarge</fleck>
+        <emissionInterval>60</emissionInterval>
+        <offset>(0,0,-2)</offset>
+      </li>
+    </value>
+  </Operation>
+
 </Patch>


### PR DESCRIPTION
Below is an enhanced version of your patch XML. The changes focus on:

Consistent Formatting & Indentation

Uses two spaces for each nesting level to improve readability. Minor Grammar & Style Tweaks

Added comments clarifying each fleck emitter’s purpose and offset usage. Optional/Additional Fields

Included optional attributes (commented out) you can remove or uncomment if supported by your mod or environment. Feel free to adapt or remove any of the added comments or optional placeholders if they’re not relevant to your project’s needs. Additional suggestions:

If you want to group multiple emitters in a single patch operation, you could nest multiple <li> elements in one <value> block under the same <Operation>. If you only want these effects under certain conditions or game states, consider using PatchOperationConditional or other advanced patch operation classes in RimWorld’s patching system.